### PR TITLE
Sleep card update: fetch hours from mock service and auto-refresh UI

### DIFF
--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -38,7 +38,14 @@
       <!-- Card Content -->
       <div class="metric-content">
         <div class="metric-value-container">
-          <span class="metric-value">{{ metric.value }}</span>
+          <span class="metric-value">
+            <ng-container *ngIf="metric.id !== 'sleep'; else sleepValue">
+              {{ metric.value }}
+            </ng-container>
+            <ng-template #sleepValue>
+              {{ ((sleepHours$ | async) ?? 0) | number:'1.1-1' }}
+            </ng-template>
+          </span>
           <span class="metric-unit">{{ metric.unit }}</span>
         </div>
         
@@ -46,7 +53,7 @@
         <div class="metric-progress">
           <div 
             class="progress-bar"
-            [style.width.%]="metric.progress"
+            [style.width.%]="metric.id === 'sleep' ? computeSleepProgress(((sleepHours$ | async) ?? 0)) : metric.progress"
             [style.background]="metric.bgGradient"
           ></div>
         </div>
@@ -54,7 +61,7 @@
         <!-- Badge for progress percentage -->
         <div class="metric-badge">
           <span class="e-badge e-badge-pill" [style.background-color]="metric.color">
-            {{ metric.progress }}%
+            {{ metric.id === 'sleep' ? computeSleepProgress(((sleepHours$ | async) ?? 0)) : metric.progress }}%
           </span>
         </div>
       </div>

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HealthDataService } from '../services/health-data.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-dashboard',
@@ -10,6 +12,9 @@ import { CommonModule } from '@angular/common';
 })
 export class DashboardComponent {
   title = 'HealthTrack Dashboard';
+
+  // Live data stream for sleep hours
+  sleepHours$: Observable<number>;
   
   // Sample health metrics data
   healthMetrics = [
@@ -46,14 +51,25 @@ export class DashboardComponent {
     {
       id: 'sleep',
       title: 'Sleep Hours',
-      value: '7.5',
+      value: '', // value will be provided dynamically from service
       unit: 'hrs',
       icon: '😴',
       color: '#8b5cf6',
       bgGradient: 'linear-gradient(135deg, #8b5cf6, #7c3aed)',
-      progress: 85
+      progress: 0 // progress will be computed dynamically
     }
   ];
+
+  constructor(private healthData: HealthDataService) {
+    this.sleepHours$ = this.healthData.sleepHours$;
+  }
+
+  // Compute progress based on an 8-hour goal
+  computeSleepProgress(hours: number): number {
+    const goal = 8;
+    const pct = Math.round((Math.max(0, Math.min(hours, goal)) / goal) * 100);
+    return pct;
+  }
 
   getCurrentDate(): string {
     const today = new Date();

--- a/src/app/services/health-data.service.ts
+++ b/src/app/services/health-data.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, interval, map } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class HealthDataService {
+  private sleepHoursSubject = new BehaviorSubject<number>(7.5);
+  sleepHours$: Observable<number> = this.sleepHoursSubject.asObservable();
+
+  constructor() {
+    // Mock data stream: update sleep hours every 5 seconds
+    interval(5000)
+      .pipe(
+        map(() => this.generateRandomSleepHours())
+      )
+      .subscribe((value: number) => this.sleepHoursSubject.next(value));
+  }
+
+  // Simulate fetching latest sleep hours from a backend/mock source
+  private generateRandomSleepHours(): number {
+    // Random between 6.0 and 9.0 with 0.1 precision
+    const min = 6.0;
+    const max = 9.0;
+    const value = Math.random() * (max - min) + min;
+    return Math.round(value * 10) / 10;
+  }
+}


### PR DESCRIPTION
This PR fixes the Sleep Hours card to fetch data from HealthService instead of a hardcoded value